### PR TITLE
Add betterError as an immediate dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dependency-env": "https://github.com/reasonml/dependency-env.git",
     "reason": "https://github.com/facebook/reason.git",
     "rebel": "https://github.com/reasonml/rebel.git",
+    "ocamlBetterErrors": "0.0.10",
     "realpath": "*"
   }
 }


### PR DESCRIPTION
Yarn doesn't allow transitive dependencies to be installed in node_modules/.bin directory.
In order to use betterError, we need to add it as an immediate dependency.

After this diff, we should be able to install this project through yarn.

@vramana @jordwalke 