### PR TITLE
explicitly require ocaml@4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@opam-alpha/merlin": "^ 2.5.0",
+    "@opam-alpha/ocaml": "4.2.3",
     "nopam": "https://github.com/reasonml/nopam.git",
     "dependency-env": "https://github.com/reasonml/dependency-env.git",
     "reason": "https://github.com/facebook/reason.git",


### PR DESCRIPTION
Somehow we need to explicitly require ocaml@4.2.3 to make yarn happy about peer deps. With this patch, we can install the example project using yarn on linux.